### PR TITLE
Updating project storage to more generic name

### DIFF
--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -3,4 +3,4 @@
 location:
   type: app_store
   name: tk-core
-  version: v0.20.1
+  version: v0.20.23

--- a/core/includes/3dequalizer_templates.yml
+++ b/core/includes/3dequalizer_templates.yml
@@ -57,74 +57,74 @@ paths:
     # define the location of a work area
     3dequalizer_shot_work_area:
         definition: '@shot_root/3dequalizer'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # define the location of a publish area
     3dequalizer_shot_publish_area:
         definition: '@shot_root/publish/3dequalizer'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of WIP files
     3dequalizer_shot_work:
         definition: '@shot_root/3dequalizer/scenes/{Shot}_{task_name}[_{name}]_v{version}.{3dequalizer_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
         
     # The location of published 3dequalizer files
     3dequalizer_shot_publish:
         definition: '@shot_root/publish/3dequalizer/{Shot}_{task_name}[_{name}]_v{version}.{3dequalizer_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # the Location of 3dequalizer published Camera's
     3dequalizer_shot_camera_publish:
         definition: '@shot_root/publish/3dequalizer/cameras/{Shot}_{task_name}[_{name}]_v{version}.mel'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # the Location of 3dequalizer published distortion Node's
     3dequalizer_shot_dist_publish:
         definition: '@shot_root/publish/3dequalizer/distNode/{Shot}_{task_name}[_{name}]_v{version}.nk'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # the Location of 3dequalizer published distortion Renderscript's
     3dequalizer_shot_distRender_publish:
         definition: '@shot_root/publish/3dequalizer/distRender/{Shot}_{task_name}[_{name}]_v{version}.nk'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     # the location of 3dequalizer published undistorted plates
     3dequalizer_shot_undist_plates_publish:
         definition: '@shot_root/publish/3dequalizer/undistRender/v{version}/{Shot}_{task_name}[_{name}]_v{version}.{3DESEQ}.jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     
     # the location of 3dequalizer published playblast plates
     3dequalizer_shot_playblast_publish:
         definition: '@shot_root/publish/3dequalizer/playblast/v{version}/{Shot}_{task_name}[_{name}]_v{version}.{3DESEQ}.jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     # the location of 3dequalizer published playblast plates
     3dequalizer_shot_playblast_cones_publish:
         definition: '@shot_root/publish/3dequalizer/playblast/v{version}/{Shot}_{task_name}[_{name}]_cones_v{version}.{3DESEQ}.jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     
     # the location of 3dequalizer published playblast plates
     3dequalizer_shot_playblast_wire_publish:
         definition: '@shot_root/publish/3dequalizer/playblast/v{version}/{Shot}_{task_name}[_{name}]_wire_v{version}.{3DESEQ}.jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     ########################################ASSET WORK
     # define the location of a work area
     3dequalizer_asset_work_area:
         definition: '@asset_root/work/3dequalizer'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # define the location of a publish area
     3dequalizer_asset_publish_area:
         definition: '@asset_root/publish/3dequalizer'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of WIP files
     3dequalizer_asset_work:
         definition: '@asset_root/work/3dequalizer/scenes/{Asset}_{task_name}[_{name}]_v{version}.{3dequalizer_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of published 3dequalizer files
     3dequalizer_asset_publish:
         definition: '@asset_root/publish/3dequalizer/{Asset}_{task_name}[_{name}]_v{version}.{3dequalizer_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # the Location of 3dequalizer published Camera's
     3dequalizer_asset_camera_publish:
         definition: '@asset_root/publish/3dequalizer/cameras/{Asset}_{task_name}[_{name}]_v{version}.mel'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     
 
     # # 3dequalizer Object export 
@@ -137,11 +137,11 @@ paths:
     # Render location for asset renders
     3dequalizer_asset_renders_step:
         definition: '@asset_render_root/3dequalizera/{task_name}/version'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     3dequalizer_asset_renders_stub:
         definition: '@asset_render_root/3dequalizer/{task_name}/version/{Asset}_{task_name}[_{name}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     3dequalizer_deadline_temp:
         definition: 'admin/processing/temp/deadline'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'

--- a/core/includes/houdini_templates.yml
+++ b/core/includes/houdini_templates.yml
@@ -106,79 +106,79 @@ paths:
     # define the location of a work area
     houdini_shot_work_area:
         definition: '@shot_root/houdini'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # define the location of a publish area
     houdini_shot_publish_area:
         definition: '@shot_root/publish/houdini'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of WIP files
     houdini_shot_work:
         definition: '@houdini_shot_work_area/scenes/@houdini_shot_hipfile.{houdini_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of backups of WIP files
     houdini_shot_snapshot:
         definition: '@houdini_shot_work_area/snapshots/@houdini_shot_hipfile.{timestamp}.{houdini_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of published houdini files
     houdini_shot_publish:
         definition: '@houdini_shot_publish_area/@houdini_shot_hipfile.{houdini_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     ######################################## ASSET WORK
     # define the location of a work area
     houdini_asset_work_area:
         definition: '@asset_root/work/houdini'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # define the location of a publish area
     houdini_asset_publish_area:
         definition: '@asset_root/publish/houdini'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of WIP files
     houdini_asset_work:
         definition: '@asset_root/work/houdini/scenes/@houdini_asset_hipfile.{houdini_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of backups of WIP files
     houdini_asset_snapshot:
         definition: '@asset_root/work/houdini/snapshots/@houdini_asset_hipfile.{timestamp}.{houdini_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of published houdini files
     houdini_asset_publish:
         definition: '@asset_root/publish/houdini/@houdini_asset_hipfile.{houdini_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     ######################################## SHOT OUTPUT
     # Rendered images go to render root
     houdini_shot_render_step:
         definition: '@render_root/houdini/{task_name}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_shot_render_step_ver:
         definition: '@render_root/houdini/{task_name}/version'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_shot_render_root:
         definition: '@houdini_shot_render_step_ver/@houdini_shot_hipfile'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_shot_render_exr:
         definition: '@houdini_shot_render_root/[{houdini.node}/]@houdini_shot_node_version.{HSEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_shot_render_multi_exr:
         definition: '@houdini_shot_render_root/[{houdini.node}/]@houdini_shot_node_version_{channel_group}.{HSEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_shot_render_multi_tiled_exr:
         definition: '@houdini_shot_render_root/[{houdini.node}/]@houdini_shot_node_version_{channel_group}.{tile_index}.{HSEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # Additional mantra SHOT outputs stay in the project folder
     # ifd is "compiled" hip scene for rendering mantra still has to render it
     houdini_shot_ifd:
         definition: '@houdini_shot_render_step/ifds/@houdini_shot_hipfile/[{houdini.node}/]@houdini_shot_node_version.{HSEQ}.ifd'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_shot_vdb:
         definition: '@houdini_shot_render_step/vdbs/@houdini_shot_hipfile/[{houdini.node}/]@houdini_shot_node_version.{HSEQ}.vdb'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # potentially very large file size deep camera maps
     houdini_shot_dcm:
         definition: '@houdini_shot_render_step/dcm/@houdini_shot_hipfile/[{houdini.node}/]@houdini_shot_node_version.{HSEQ}.dcm'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_shot_extra_plane:
         definition: '@houdini_shot_render_root/[{houdini.node}/]@houdini_shot_node_version_{aov_name}.{HSEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # Additional geometry Shot node outputs
     houdini_shot_work_geo_cache:
         definition: '@houdini_shot_cache_root/geometry/@houdini_shot_hipfile/[{houdini.node}/]@houdini_shot_node_version.{HSEQ}.bgeo.sc'
@@ -215,44 +215,44 @@ paths:
     # Playblast output
     houdini_shot_playblast_root:
         definition: '@render_root/houdini/{task_name}/flip'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_shot_playblast_output:
         definition: '@houdini_shot_playblast_root/@houdini_shot_hipfile/@houdini_shot_hipfile'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_shot_playblast_publishing:
         definition: '@houdini_shot_playblast_output.{HSEQ}.jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_shot_playblast_mov:
         definition: '@houdini_shot_playblast_output.mov'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     ######################################## ASSET OUTPUT       
     # Rendered images
     houdini_asset_render_step:
         definition: '@asset_render_root/houdini/{task_name}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_asset_render_step_ver:
         definition: '@asset_render_root/houdini/{task_name}/version'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_asset_render_root:
         definition: '@houdini_asset_render_step_ver/@houdini_asset_hipfile'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_asset_render_exr:
         definition: '@houdini_asset_render_root/[{houdini.node}/]@houdini_asset_node_version.{HSEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # Additional mantra outputs
     houdini_asset_ifd:
         definition: '@houdini_asset_render_step/ifds/@houdini_asset_hipfile/[{houdini.node}/]@houdini_asset_node_version.{HSEQ}.ifd'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_asset_vdb:
         definition: '@houdini_asset_render_step/vdbs/@houdini_asset_hipfile/[{houdini.node}/]@houdini_asset_node_version.{HSEQ}.vdb'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_asset_dcm:
         definition: '@houdini_asset_render_step/dcms/@houdini_asset_hipfile/[{houdini.node}/]@houdini_asset_node_version.{HSEQ}.dcm'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_asset_extra_plane:
         definition: '@houdini_asset_render_root_{aov_name}/[{houdini.node}/]@houdini_asset_node_version.{HSEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # Additional geometry Asset cache node outputs
     houdini_asset_work_geo_cache:
         definition: '@houdini_asset_cache_root/geometry/@houdini_asset_hipfile/[{houdini.node}/]@houdini_asset_node_version.{HSEQ}.bgeo.sc'
@@ -280,13 +280,13 @@ paths:
     # playblast output
     houdini_asset_playblast_root:
         definition: '@asset_render_root/houdini/{task_name}/flip'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_asset_playblast_output:
         definition: '@houdini_asset_playblast_root/@houdini_asset_hipfile/@houdini_asset_hipfile'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_asset_playblast_publishing:
         definition: '@houdini_asset_playblast_output.{HSEQ}.jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     houdini_asset_playblast_mov:
         definition: '@houdini_asset_playblast_output.mov'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'

--- a/core/includes/mari_templates.yml
+++ b/core/includes/mari_templates.yml
@@ -51,13 +51,13 @@ keys:
 paths:
     asset_mari_texture_exr:
         definition: '@asset_root/publish/mari/v{version}/{mari.channel}_v{version}/exr/{Asset}_{mari.channel}[_{mari.layer}].v{version}.{UDIM}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     asset_mari_texture_tx:
         definition: '@asset_root/publish/mari/v{version}/{mari.channel}_v{version}/tx/{Asset}_{mari.channel}[_{mari.layer}].v{version}.{UDIM}.tx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     asset_mari_texture_rat:
         definition: '@asset_root/publish/mari/v{version}/{mari.channel}_v{version}/rat/{Asset}_{mari.channel}[_{mari.layer}].v{version}.{UDIM}.rat'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
 strings:
     # Define a new Mari project name

--- a/core/includes/max_templates.yml
+++ b/core/includes/max_templates.yml
@@ -16,61 +16,61 @@ paths:
     # define the location of a work area
     max_shot_work_area:
         definition: '@shot_root/work/3dsmax'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # define the location of a publish area
     max_shot_publish_area:
         definition: '@shot_root/publish/3dsmax'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of WIP files
     max_shot_work:
         definition: '@shot_root/work/3dsmax/{Shot}_{task_name}[_{name}]_v{version}.max'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of backups of WIP files
     max_shot_snapshot:
         definition: '@shot_root/work/3dsmax/snapshots/{Shot}_{task_name}[_{name}]_v{version}.{timestamp}.max'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of published max files
     max_shot_publish:
         definition: '@shot_root/publish/3dsmax/{Shot}_{task_name}_v{version}.max'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     ########################################ASSET WORK
     # define the location of a work area
     max_asset_work_area:
         definition: '@asset_root/work/3dsmax'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # define the location of a publish area
     max_asset_publish_area:
         definition: '@asset_root/publish/3dsmax'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of WIP files
     max_asset_work:
         definition: '@asset_root/work/3dsmax/{Asset}_{task_name}[_{name}]_v{version}.max'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of backups of WIP files
     max_asset_snapshot:
         definition: '@asset_root/work/3dsmax/snapshots/{Asset}_{task_name}[_{name}]_v{version}.{timestamp}.max'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of published max files
     max_asset_publish:
         definition: '@asset_root/publish/3dsmax/{Asset}_{task_name}_v{version}.max'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     ########################################SHOT OUTPUT
     # version output
     max_shot_renders_step:
         definition: '@render_root/3dsmax/{task_name}/version/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     max_shot_render_exr:
         definition: '@render_root/3dsmax/{task_name}/version/{Shot}_{task_name}[_{3dsmax.render.output}]_v{version}/{Shot}_{task_name}[_{3dsmax.render.output}]_v{version}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     max_shot_render_jpg:
         definition: '@render_root/3dsmax/{task_name}/version/{Shot}_{task_name}[_{3dsmax.render.output}]_v{version}/{Shot}_{task_name}[_{3dsmax.render.output}]_v{version}.jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     max_shot_render_png:
         definition: '@render_root/3dsmax/{task_name}/version/{Shot}_{task_name}[_{3dsmax.render.output}]_v{version}/{Shot}_{task_name}[_{3dsmax.render.output}]_v{version}.png'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     max_shot_render_exr_pub:
         definition: '@render_root/3dsmax/{task_name}/publish/{Shot}_{task_name}_v{version}/{Shot}_{task_name}_v{version}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # 3dMax Simulations output
     max_shot_sim_ffx:
         definition: '@shot_context/3dsmax/{task_name}/caches/sim/{Shot}_{task_name}[_{3dsmax.render.output}]_v{version}/{Shot}_{task_name}[_{3dsmax.render.output}]_v{version}.fxd'
@@ -82,27 +82,27 @@ paths:
      # review output
     max_shot_quicktime_quick:
         definition: '@temp_shot_root/3dsmax/{task_name}/review/quickdaily/{Shot}_v{version}_{iteration}.mov'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     max_shot_render_movie:
         definition: '@temp_shot_root/3dsmax/{task_name}/review/{Shot}_review/{Shot}_review_v{version}.mov'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     max_shot_render_filmstrip:
         definition: '@temp_shot_root/3dsmax/{task_name}/review/{Shot}_revie/{Shot}_review_v{version}.png'
-        root_name: 'project_pipeline' 
+        root_name: 'project_storage_pix'
     ########################################ASSET OUTPUT       
     # Render location for asset renders
     max_asset_render_exr:
         definition: '@asset_render_root/3dsmax/{task_name}/version/{Asset}_{task_name}[_{3dsmax.render.output}]_v{version}/{Asset}_{task_name}[_{3dsmax.render.output}]_v{version}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     max_asset_render_jpg:
         definition: '@asset_render_root/3dsmax/{task_name}/version/{Asset}_{task_name}[_{3dsmax.render.output}]_v{version}/{Asset}_{task_name}[_{3dsmax.render.output}]_v{version}.jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     max_asset_render_png:
         definition: '@asset_render_root/3dsmax/{task_name}/version/{Asset}_{task_name}[_{3dsmax.render.output}]_v{version}/{Asset}_{task_name}[_{3dsmax.render.output}]_v{version}.png'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     max_asset_render_exr_pub:
         definition: '@asset_render_root/3dsmax/{task_name}/version/{Asset}_{task_name}_v{version}/{Asset}_{task_name}_v{version}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # 3dMax Simulations output
     max_asset_sim:
         definition: '@asset_context/3dsmax/{task_name}/caches/sim/{Asset}_{task_name}[_{3dsmax.cache.output}]_v{version}/{Asset}_{task_name}[_{3dsmax.cache.output}]_v{version}.fxd'
@@ -111,4 +111,3 @@ paths:
     max_asset_cache_alembic:
         definition: '@asset_context/3dsmax/{task_name}/caches/geometry/{Asset}_{task_name}[_{3dsmax.cache.output}]_v{version}/{Asset}_{task_name}[_{3dsmax.cache.output}]_v{version}.abc'
         root_name: 'caches'
-

--- a/core/includes/maya_templates.yml
+++ b/core/includes/maya_templates.yml
@@ -72,96 +72,96 @@ paths:
     # define the location of a work area
     maya_shot_work_area:
         definition: '@shot_root/maya'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # define the location of a publish area
     maya_shot_publish_area:
         definition: '@shot_root/publish/maya'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of WIP files
     maya_shot_work:
         definition: '@shot_root/maya/scenes/{Shot}_{task_name}[_{name}]_v{version}.{maya_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
         
     # The location of backups of WIP files
     maya_shot_snapshot:
         definition: '@shot_root/maya/snapshots/{Shot}_{task_name}[_{name}]_v{version}_{timestamp}.{maya_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of published maya files
     maya_shot_publish:
         definition: '@shot_root/publish/maya/{Shot}_{task_name}[_{name}]_v{version}.{maya_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # the Location of Maya published Camera's
     maya_shot_camera_publish:
         definition: '@shot_root/publish/maya/cameras/{Shot}_{task_name}[_{name}]_v{version}.abc'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     
     ########################################ASSET WORK
     # define the location of a work area
     maya_asset_work_area:
         definition: '@asset_root/work/maya'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # define the location of a publish area
     maya_asset_publish_area:
         definition: '@asset_root/publish/maya'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of WIP files
     maya_asset_work:
         definition: '@asset_root/work/maya/scenes/{Asset}_{task_name}[_{name}]_v{version}.{maya_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of backups of WIP files
     maya_asset_snapshot:
         definition: '@asset_root/work/maya/snapshots/{Asset}_{task_name}[_{name}]_v{version}_{timestamp}.{maya_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of published maya files
     maya_asset_publish:
         definition: '@asset_root/publish/maya/{Asset}_{task_name}[_{name}]_v{version}.{maya_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # # The location of published maya geometry files
     asset_alembic_cache:
         definition: '@asset_root/publish/maya/geometry/{Asset}_{task_name}[_{name}]_v{version}.{maya_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of published maya shader files
     maya_shader_network_publish:
         definition: '@asset_root/publish/maya/surfacing/{Asset}_{task_name}[_{name}]_v{version}.{maya_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # the Location of Maya published Camera's
     maya_asset_camera_publish:
         definition: '@asset_root/publish/maya/cameras/{Asset}_{task_name}[_{name}]_v{version}.abc'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of published maya assembly definition files
     maya_asset_assembly_publish:
         definition: '@asset_root/publish/maya/{Asset}_{task_name}[_{name}]_assembly_v{version}.{maya_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_asset_standin_publish:
         definition: '@asset_root/publish/maya/standin/{Asset}_{task_name}[_{name}]_v{version}/{Asset}_{task_name}[_{name}]_v{version}.ass'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     
     ########################################SHOT OUTPUT
     # version output
     maya_shot_renders_step:
         definition: '@render_root/maya/{task_name}/version'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_shot_render_stub:
         definition: '@render_root/maya/{task_name}/version/{Shot}_{task_name}[_{name}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_shot_render_layer:
         definition: '@maya_shot_render_stub/{maya.layer_name}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_shot_render_thumb_jpeg:
         definition: '@temp_shot_root/thumbnails/{Shot}_{task_name}[_{name}]_v{version}/[{maya.layer_name}/]{Shot}_{task_name}[_{maya.layer_name}]_v{version}.jpeg'
         root_name: 'secondary'
     maya_shot_render_exr:
         definition: '@render_root/maya/{task_name}/version/{Shot}_{task_name}[_{name}]_v{version}/[{maya.layer_name}/]{Shot}_{task_name}[_{maya.layer_name}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_shot_render_jpg:
         definition: '@render_root/maya/{task_name}/version/{Shot}_{task_name}[_{name}]_v{version}/[{maya.layer_name}/]{Shot}_{task_name}[_{maya.layer_name}]_v{version}.{SEQ}.jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_shot_render_png:
         definition: '@render_root/maya/{task_name}/version/{Shot}_{task_name}[_{name}]_v{version}/[{maya.layer_name}/]{Shot}_{task_name}[_{maya.layer_name}]_v{version}.{SEQ}.png'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_shot_render_exr_pub:
         definition: '@render_root/maya/{task_name}/publish/{Shot}_{task_name}[_{name}]_v{version}/[{maya.layer_name}/]{Shot}_{task_name}[_{maya.layer_name}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # # Maya Simulations output 
     # fxd = fume effects
     maya_shot_sim_ffx:
@@ -199,58 +199,58 @@ paths:
     # review output
     maya_shot_playblast_root:
         definition: '@render_root/maya/{task_name}/playblast/{Shot}_{task_name}[_{maya.techpass_name}][_{name}]_pb_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_shot_playblast_output:
         definition: '@maya_shot_playblast_root/{Shot}_{task_name}[_{maya.techpass_name}][_{name}]_pb_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_shot_playblast_publishing:
         definition: '@maya_shot_playblast_root/{Shot}_{task_name}[_{maya.techpass_name}][_{name}]_pb_v{version}.{SEQ}.jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_shot_quicktime_quick:
         definition: '@render_root/maya/{task_name}/review/quickdaily/{Shot}[_{name}]_v{version}_{iteration}.mov'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_shot_render_filmstrip:
         definition: '@render_root/maya/{task_name}/review/{Shot}_review/{Shot}[_{name}]_review_v{version}.{SEQ}.png'
-        root_name: 'project_pipeline' 
+        root_name: 'project_storage_pix'
 
     ######################################## ASSET OUTPUT       
     # Render location for asset renders
     maya_asset_renders_step:
         definition: '@asset_render_root/maya/{task_name}/version'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_asset_renders_stub:
         definition: '@asset_render_root/maya/{task_name}/version/{Asset}_{task_name}[_{name}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_asset_renders_layer:
         definition: '@maya_asset_renders_stub/{maya.layer_name}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_asset_render_thumb_jpeg:
         definition: '@temp_shot_root/thumbnails/{Asset}_{task_name}[_{name}]_v{version}/[{maya.layer_name}/]{Asset}_{task_name}[_{name}]_v{version}.jpeg'
         root_name: 'secondary'
     maya_asset_render_exr:
         definition: '@maya_asset_renders_step/{Asset}_{task_name}[_{name}]_v{version}/[{maya.layer_name}/]{Asset}_{task_name}[_{maya.layer_name}]_v{version}.[{SEQ}.]exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_asset_render_jpg:
         definition: '@maya_asset_renders_step/{Asset}_{task_name}[_{name}]_v{version}/[{maya.layer_name}/]{Asset}_{task_name}[_{maya.layer_name}]_v{version}.[{SEQ}.]jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_asset_render_jpeg:
         definition: '@maya_asset_renders_step/{Asset}_{task_name}[_{name}]_v{version}/[{maya.layer_name}/]{Asset}_{task_name}[_{maya.layer_name}]_v{version}.[{SEQ}.]jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_asset_render_png:
         definition: '@maya_asset_renders_step/{Asset}_{task_name}[_{name}]_v{version}/[{maya.layer_name}/]{Asset}_{task_name}[_{maya.layer_name}]_v{version}.[{SEQ}.]png'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_asset_render_exr_pub:
         definition: '@asset_render_root/maya/{task_name}/publish/{Asset}_{task_name}[_{name}]_v{version}/[{maya.layer_name}/]{Asset}_{task_name}[_{name}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_asset_playblast_root:
         definition: '@asset_render_root/maya/{task_name}/playblast/{Asset}_{task_name}[_{maya.techpass_name}][_{name}]_pb_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_asset_playblast_output:
         definition: '@maya_asset_playblast_root/{Asset}_{task_name}[_{maya.techpass_name}][_{name}]_pb_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     maya_asset_playblast_publishing:
         definition: '@maya_asset_playblast_root/{Asset}_{task_name}[_{maya.techpass_name}][_{name}]_pb_v{version}.{SEQ}.jpg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # # Maya Simulations output
     # maya_asset_sim:
     #     definition: '@asset_context/maya/{task_name}/caches/sim/{Asset}_{task_name}_v{version}/{Asset}_{task_name}_v{version}.fxd'

--- a/core/includes/nuke_templates.yml
+++ b/core/includes/nuke_templates.yml
@@ -20,157 +20,157 @@ paths:
     ########################################SHOT WORK   
     nuke_shot_render_area:
         definition: '@shot_context/renders'
-        root_name: 'project_pipeline'    
+        root_name: 'project_storage_pix'
     # define the location of a work area
     nuke_shot_work_area:
         definition: '@shot_root/nuke'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # define the location of a publish area
     nuke_shot_publish_area:
         definition: '@shot_root/nuke/publish'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of WIP script files
     nuke_shot_work:
         definition: '@nuke_shot_work_area/{Shot}_{task_name}[_{name}]_v{version}.nk'
-        root_name: 'project_pipeline'   
+        root_name: 'project_storage_pix'
     # The location of WIP script files
     nuke_shot_submission_root:
         definition: '@shot_root/submission/nuke/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of backups of WIP files
     nuke_shot_snapshot:
         definition: '@nuke_shot_work_area/snapshots/{Shot}_{task_name}[_{name}]_v{version}.{timestamp}.nk'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of published nuke script files
     # nuke_shot_publish:
     #     definition: '@nuke_shot_publish_area/{Shot}_{task_name}[_{name}]_v{version}.nk'
     #     root_name: 'secondary'
     nuke_shot_publish:
         definition: '@publish_shot_records/{Shot}/{task_name}/{Shot}_{task_name}[_{name}]_v{version}.nk'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_review_template:
         definition: '@client_submission_folder/nuke_script/nuke_submission_review.nk'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_review_template2:
         definition: '@processing_root/nuke_scripts/processing_review.nk'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     ########################################ASSET WORK
     # define the location of a work area
     nuke_asset_work_area:
         definition: '@asset_root/work/nuke'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # define the location of a publish area
     nuke_asset_publish_area:
         definition: '@asset_root/publish/nuke'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of WIP script files
     nuke_asset_work:
         definition: '@asset_root/work/nuke/{Asset}_{task_name}[_{name}]_v{version}.nk'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of backups of WIP files
     nuke_asset_snapshot:
         definition: '@asset_root/work/nuke/snapshots/{Asset}_{task_name}[_{name}]_v{version}.{timestamp}.nk'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of published nuke script files
     nuke_asset_publish:
         definition: '@publish_asset_records/{Asset}/{task_name}/{Asset}_{task_name}_v{version}.nk'
-        root_name: 'project_pipeline' 
+        root_name: 'project_storage_pix'
     ########################################SHOT OUTPUT   
     # sequence render roots
     nuke_shot_render_root:
         definition: '@render_root/nuke/{task_name}/version/{Shot}_{task_name}[_{nuke.output}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_pub_root:
         definition: '@render_root/nuke/{task_name}/publish/{Shot}_{task_name}_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_element_render_root:
         definition: '@render_root/nuke/{task_name}/element/{Shot}_elem[_{nuke.output}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_denoise_render_root:
         # definition: '@render_root/nuke/element/denoise/{Shot}_{task_name}[_{nuke.output}]_v{version}'
         definition: '@render_root/nuke/element/denoise/{Shot}_denoise[_{nuke.output}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_stmap_render_root:
         # definition: '@render_root/nuke/element/STMap/{Shot}_{task_name}[_{nuke.output}]_v{version}'
         definition: '@render_root/nuke/element/STMap/{Shot}_STMap[_{nuke.output}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_smartvector_render_root:
         # definition: '@render_root/nuke/element/SmartVector/{Shot}_{task_name}[_{nuke.output}]_v{version}'
         definition: '@render_root/nuke/element/SmartVector/{Shot}_SmartVector[_{nuke.output}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_test_render_root:
         definition: '@temp_shot_root/renders/nuke/{task_name}/test/{Shot}_test[_{nuke.output}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # version output
     nuke_shot_render_jpeg:
         definition: '@nuke_shot_render_root/{Shot}_{task_name}[_{nuke.output}]_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_exr:
         definition: '@nuke_shot_render_root/{Shot}_{task_name}[_{nuke.output}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_dpx:
         definition: '@nuke_shot_render_root/{Shot}_{task_name}[_{nuke.output}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # publish output
     nuke_shot_render_pub_jpeg:
         definition: '@nuke_shot_render_pub_root/{Shot}_{task_name}_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_pub_dpx:
         definition: '@nuke_shot_render_pub_root/{Shot}_{task_name}_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_pub_exr:
         definition: '@nuke_shot_render_pub_root/{Shot}_{task_name}_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # element output
     nuke_shot_render_element_jpeg:
         definition: '@nuke_shot_element_render_root/{Shot}_elem[_{nuke.output}]_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_element_exr:
         definition: '@nuke_shot_element_render_root/{Shot}_elem[_{nuke.output}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_element_dpx:
         definition: '@nuke_shot_element_render_root/{Shot}_elem[_{nuke.output}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # denoise output
     nuke_shot_render_denoise_jpeg:
         definition: '@nuke_shot_denoise_render_root/{Shot}_denoise[_{nuke.output}]_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_denoise_exr:
         definition: '@nuke_shot_denoise_render_root/{Shot}_denoise[_{nuke.output}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_denoise_dpx:
         definition: '@nuke_shot_denoise_render_root/{Shot}_denoise[_{nuke.output}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'   
+        root_name: 'project_storage_pix'
     # stmap output
     nuke_shot_render_stmap_jpeg:
         definition: '@nuke_shot_stmap_render_root/{Shot}_STMap[_{nuke.output}]_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_stmap_exr:
         definition: '@nuke_shot_stmap_render_root/{Shot}_STMap[_{nuke.output}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_stmap_dpx:
         definition: '@nuke_shot_stmap_render_root/{Shot}_STMap[_{nuke.output}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'        
+        root_name: 'project_storage_pix'
     # smartvector output
     nuke_shot_render_smartvector_jpeg:
         definition: '@nuke_shot_smartvector_render_root/{Shot}_SmartVector[_{nuke.output}]_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_smartvector_exr:
         definition: '@nuke_shot_smartvector_render_root/{Shot}_SmartVector[_{nuke.output}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_smartvector_dpx:
         definition: '@nuke_shot_smartvector_render_root/{Shot}_SmartVector[_{nuke.output}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'              
+        root_name: 'project_storage_pix'
     # render movie    
     nuke_shot_render_mov:
         definition: '@temp_shot_root/renders/nuke/{task_name}/review/{Shot}_{task_name}[_{name}]_v{version}/{Shot}_{task_name}[_{name}]_v{version}.mov'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_shot_render_mov_secondary:
         definition: '@nuke_shot_render_mov'
         root_name: 'secondary'         
     nuke_shot_render_filmstrip:
         definition: '@temp_shot_root/renders/nuke/{task_name}/review/{Shot}_{task_name}[_{nuke.output}]_v{version}/{Shot}_{task_name}[_{nuke.output}]_v{version}.png'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # test output
     nuke_shot_render_test_jpeg:
         definition: '@nuke_shot_test_render_root/{Shot}_test[_{nuke.output}]_v{version}.{SEQ}.jpeg'
@@ -184,52 +184,52 @@ paths:
     ########################################ASSET OUTPUT     
     nuke_asset_render_root:
         definition: '@asset_render_root/nuke/{task_name}/version/{Asset}_{task_name}[_{nuke.output}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_publish_root:
         definition: '@asset_render_root/nuke/{task_name}/publish'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_element_render_root:
         definition: '@asset_render_root/nuke/{task_name}/element/{Asset}_elem[_{nuke.output}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_denoise_render_root:
         definition: '@asset_render_root/nuke/element/denoise/{Asset}_denoise[_{nuke.output}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_stmap_render_root:
         definition: '@asset_render_root/nuke/element/STMap/{Asset}_stmap[_{nuke.output}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_smartvector_render_root:
         definition: '@asset_render_root/nuke/element/SmartVector/{Asset}_SmartVector[_{nuke.output}]_v{version}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # version output
     nuke_asset_render_jpeg:
         definition: '@nuke_asset_render_root/{Asset}_{task_name}[_{nuke.output}]_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_exr:
         definition: '@nuke_asset_render_root/{Asset}_{task_name}[_{nuke.output}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_dpx:
         definition: '@nuke_asset_render_root/{Asset}_{task_name}[_{nuke.output}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # publish output
     nuke_asset_render_pub_jpeg:
         definition: '@nuke_asset_publish_root/{Asset}_{task_name}_v{version}/{Asset}_{task_name}_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_pub_exr:
         definition: '@nuke_asset_publish_root/{Asset}_{task_name}_v{version}/{Asset}_{task_name}_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_pub_dpx:
         definition: '@nuke_asset_publish_root/{Asset}_{task_name}[_{nuke.output}]_v{version}/{Asset}_{task_name}[_{nuke.output}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'            
+        root_name: 'project_storage_pix'
     # element output
     nuke_asset_render_element_jpeg:
         definition: '@nuke_asset_element_render_root/{Asset}_elem[_{nuke.output}]_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_element_exr:
         definition: '@nuke_asset_element_render_root/{Asset}_elem[_{nuke.output}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_element_dpx:
         definition: '@nuke_asset_element_render_root/{Asset}_elem[_{nuke.output}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'                
+        root_name: 'project_storage_pix'
     # test output     
     nuke_asset_render_test_jpeg:
         definition: '@temp_asset_render_root/nuke/{task_name}/test/{Asset}_test[_{nuke.output}]_v{version}/{Asset}_test[_{nuke.output}]_v{version}.{SEQ}.jpeg'
@@ -243,50 +243,50 @@ paths:
     # render movie
     nuke_asset_render_mov:
         definition: '@temp_asset_render_root/renders/nuke/{task_name}/review/{Asset}_{task_name}[_{name}]_v{version}/{Asset}_{task_name}[_{name}]_v{version}.mov'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_mov_secondary:
         definition: '@temp_asset_render_root/renders/nuke/{task_name}/review/{Asset}_{task_name}[_{name}]_v{version}/{Asset}_{task_name}[_{name}]_v{version}.mov'
         root_name: 'secondary'
     nuke_asset_render_filmstrip:
         definition: '@temp_asset_render_root/renders/nuke/{task_name}/review/{Asset}_{task_name}[_{nuke.output}]_v{version}/{Asset}_{task_name}[_{nuke.output}]_v{version}.png'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # review output
     nuke_asset_render_movie:
         definition: '@temp_asset_render_root/nuke/{task_name}/review/{Asset}_{task_name}_review[_{nuke.output}]_v{version}/{Asset}_{nuke.output}_v{version}.mov'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_quicktime_quick:
         definition: '@temp_asset_render_root/nuke/{task_name}/review/quickdaily/{Asset}_{task_name}_v{version}/{Asset}_{name}_{iteration}.mov'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # denoise output
     nuke_asset_render_denoise_jpeg:
         definition: '@nuke_asset_denoise_render_root/{Asset}_denoise[_{nuke.output}]_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_denoise_exr:
         definition: '@nuke_asset_denoise_render_root/{Asset}_denoise[_{nuke.output}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_denoise_dpx:
         definition: '@nuke_asset_denoise_render_root/{Asset}_denoise[_{nuke.output}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'   
+        root_name: 'project_storage_pix'
     # smartvector output
     nuke_asset_render_smartvector_jpeg:
         definition: '@nuke_asset_smartvector_render_root/{Asset}_SmartVector[_{nuke.output}]_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_smartvector_exr:
         definition: '@nuke_asset_smartvector_render_root/{Asset}_SmartVector[_{nuke.output}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_smartvector_dpx:
         definition: '@nuke_asset_smartvector_render_root/{Asset}_SmartVector[_{nuke.output}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # stmap output
     nuke_asset_render_stmap_jpeg:
         definition: '@nuke_asset_stmap_render_root/{Asset}_stmap[_{nuke.output}]_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_stmap_exr:
         definition: '@nuke_asset_stmap_render_root/{Asset}_stmap[_{nuke.output}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     nuke_asset_render_stmap_dpx:
         definition: '@nuke_asset_stmap_render_root/{Asset}_stmap[_{nuke.output}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'            
+        root_name: 'project_storage_pix'
     
 strings:
     # when a review Version in Shotgun is created inside of Nuke, this is the
@@ -296,5 +296,3 @@ strings:
 
     nuke_shot_version_name: "{Shot}_{nuke.output}_v{version}.{iteration}"
     nuke_asset_version_name: "{Asset}_{nuke.output}_v{version}.{iteration}"
-
-

--- a/core/includes/outsource_templates.yml
+++ b/core/includes/outsource_templates.yml
@@ -23,43 +23,43 @@ strings:
 paths:
     incoming_outsource_shot_folder_root:
         definition: 'admin/incoming/outsource/shots/{vendor}/{YYYY}_{MM}_{DD}/@outsource_name'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     incoming_outsource_shot_subfolder_root:
         definition: '@incoming_outsource_shot_folder_root/{outsource_render}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     incoming_outsource_shot_3de_file:
         definition: '@incoming_outsource_shot_folder_root/{Shot}[_{name}]_v{version}.3de'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     maya_shot_outsource_version_abc:
         definition: '@incoming_outsource_shot_folder_root/{Shot}[_{outsource_task}][_{name}]_v{version}.abc'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     maya_shot_outsource_work_file:
         definition: '@incoming_outsource_shot_folder_root/@outsource_name.{maya_extension}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     maya_shot_outsource_notes:
         definition: '@incoming_outsource_shot_folder_root/{name}[_v{version}].{ext}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     incoming_outsource_shot_nuke_render:
         definition: '@incoming_outsource_shot_subfolder_root/[{name}/]@outsource_descriptor_name[.{SEQ}].{ext}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     incoming_outsource_shot_matchmove_render:
         definition: '@incoming_outsource_shot_subfolder_root/{name}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     incoming_outsource_shot_matchmove_qt:
         definition: '@incoming_outsource_shot_subfolder_root/{name}.{ext}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     incoming_outsource_render_copy:
         definition: '@render_root/maya/{task_name}/v{version}/{outsource_render}/[{name}/]@outsource_descriptor_name[.{SEQ}].{ext}'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     incoming_outsource_camera_copy:
         definition: '@shot_context/maya/{outsource_task}/caches/alembic/{Shot}[_{outsource_task}][_{name}]_v{version}.abc'

--- a/core/includes/photoshop_templates.yml
+++ b/core/includes/photoshop_templates.yml
@@ -3,36 +3,36 @@ paths:
     # The location of WIP script files
     psd_asset_work:
         definition: '@asset_root/psd/{Asset}_{task_name}[_{name}]_v{version}.psd'
-        root_name: 'project_pipeline'    
+        root_name: 'project_storage_pix'
     psd_shot_work:
         definition: '@shot_root/psd/{Shot}_{task_name}[_{name}]_v{version}.psd'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # The location of backups of WIP files
     psd_shot_snapshot:
         definition: '@shot_root/nuke/snapshots/{Shot}_{task_name}[_{name}]_v{version}.{timestamp}.psd'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     ## Output
     # Asset
     psd_asset_version_dpx:
         definition: '@asset_render_root/psd/{task_name}/version/{Shot}_{task_name}[_{name}]_v{version}/{Shot}_{task_name}[_{name}]_v{version}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     psd_asset_version_exr:
         definition: '@asset_render_root/psd/{task_name}/version/{Shot}_{task_name}[_{name}]_v{version}/{Shot}_{task_name}[_{name}]_v{version}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     psd_asset_version_jpeg:
         definition: '@asset_render_root/psd/{task_name}/version/{Shot}_{task_name}[_{name}]_v{version}/{Shot}_{task_name}[_{name}]_v{version}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # Shot
     psd_shot_version_dpx:
         definition: '@render_root/psd/{task_name}/version/{Shot}_{task_name}[_{name}]_v{version}/{Shot}_{task_name}[_{name}]_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     psd_shot_version_exr:
         definition: '@render_root/psd/{task_name}/version/{Shot}_{task_name}[_{name}]_v{version}/{Shot}_{task_name}[_{name}]_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     psd_shot_version_jpeg:
         definition: '@render_root/psd/{task_name}/version/{Shot}_{task_name}[_{name}]_v{version}/{Shot}_{task_name}[_{name}]_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     psd_shot_version_tif:
         definition: '@render_root/psd/{task_name}/version/{Shot}_{task_name}[_{name}]_v{version}/{Shot}_{task_name}[_{name}]_v{version}.{SEQ}.tif'
-        root_name: 'project_pipeline'        
+        root_name: 'project_storage_pix'

--- a/core/includes/submitter_templates.yml
+++ b/core/includes/submitter_templates.yml
@@ -15,24 +15,23 @@ paths:
     ### Shot Locations ###
     shot_submission_json_file: 
         definition: '@processing_root/temp/json/submissions/{Shot}/{Shot}_{task_name}[_{maya.techpass_name}][_{underscore_name}]_v{version}.json'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     ### Asset Locations ###
     asset_submission_json_file: 
         definition: '@processing_root/temp/json/submissions/{sg_asset_type}/{Asset}/{Asset}_{task_name}[_{maya.techpass_name}][_{underscore_name}]_v{version}.json'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     ### Review Locations ###
     resolve_shot_review_mov: 
         definition: 'editorial/resolve/review/{YYYY}{MM}{DD}_Resolve_Review/{ampm}/{Shot}_{task_name}[_{maya.techpass_name}][_{underscore_name}][_{process}]_v{version}.mov'
-        root_name: 'project_pipeline'        
+        root_name: 'project_storage_pix'
     resolve_shot_review_mov_secondary: 
         definition: 'editorial/resolve/review/{YYYY}{MM}{DD}_Resolve_Review/{ampm}/{Shot}_{task_name}[_{maya.techpass_name}][_{underscore_name}][_{process}]_v{version}.mov'
         root_name: 'secondary'                
     resolve_asset_review_mov: 
         definition: 'editorial/resolve/review/{YYYY}{MM}{DD}_Resolve_Review/{ampm}/{Asset}_{task_name}[_{maya.techpass_name}][_{underscore_name}][_{process}]_v{version}.mov'
-        root_name: 'project_pipeline'        
+        root_name: 'project_storage_pix'
     resolve_asset_review_mov_secondary: 
         definition: 'editorial/resolve/review/{YYYY}{MM}{DD}_Resolve_Review/{ampm}/{Asset}_{task_name}[_{maya.techpass_name}][_{underscore_name}][_{process}]_v{version}.mov'
         root_name: 'secondary' 
-

--- a/core/roots.yml
+++ b/core/roots.yml
@@ -41,7 +41,7 @@
 # core, this requirement has been lifted and the root can be named anything.
 # ------------------------------------------------------------------------------
 
-project_pipeline:
+project_storage_pix:
 
     description: A top-level root folder for production data. Project folders
         will be created beneath this location.

--- a/core/schema/project.yml
+++ b/core/schema/project.yml
@@ -12,4 +12,4 @@
 type: "project"
 
 # name of project root as defined in roots.yml
-root_name: "project_pipeline"
+root_name: "project_storage_pix"

--- a/core/templates.yml
+++ b/core/templates.yml
@@ -198,7 +198,7 @@ paths:
 
     deadline_temp_folder: 
         definition: 'admin/temp/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     #Source of all plate footage
     rushes_root: shots/{Shot}/rushes
@@ -210,19 +210,19 @@ paths:
 
     project_shots_folder: 
         definition: 'shots/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     workfile_templates: 
         definition: 'admin/workfile_templates'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
         
     deadline_submission_folder: 
         definition: 'admin/temp/scripts/deadline'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     client_submission_folder: 
         definition: 'admin/outgoing/submissions'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     
     client_submission_folder_alt: 
         definition: 'admin/outgoing/submissions'
@@ -230,93 +230,93 @@ paths:
         
     resolve_review_folder: 
         definition: 'editorial/resolve/review'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     processing_root:
         definition: 'admin/processing'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     processing_records:
         definition: '@processing_root/records'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     pump_records:
         definition: '@processing_records/pump'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     publish_records:
         definition: '@processing_records/publish'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     publish_shot_records:
         definition: '@publish_records/shots'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     publish_asset_records:
         definition: '@publish_records/assets'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     general_review_process_json:
         definition: '@processing_root/json/processing_review_settings.json'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     
     alembic_review_process_json:
         definition: '@processing_root/json/processing_incoming_alembic.json'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     shot_review_process_json2:
         definition: '@processing_root/json/shot_review_settings.json'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     asset_review_process_json2:
         definition: '@processing_root/json/asset_review_settings.json'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     # shot_submission_json_file: 
     #     definition: '@processing_root/temp/json/submissions/{Shot}/{Shot}_{task_name}[_{name}]_v{version}.json'
-    #     root_name: 'project_pipeline'
+    #     root_name: 'project_storage_pix'
 
     # asset_submission_json_file: 
     #     definition: '@processing_root/temp/json/submissions/{sg_asset_type}/{Asset}/{Asset}_{task_name}[_{name}]_v{version}.json'
-    #     root_name: 'project_pipeline'
+    #     root_name: 'project_storage_pix'
 
     shot_review_process_json:
         definition: '@processing_root/json/shot_processing_review_settings.json'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     asset_review_process_json:
         definition: '@processing_root/json/asset_processing_review_settings.json'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     artist_work_render: 
         definition: 'editorial/work/renders'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     version_zero_internal: 
         definition: 'editorial/v000s'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     version_zero_client: 
         definition: 'admin/outgoing/submissions/V000s'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
         
     project_slate: 
         definition: 'admin/outgoing/slate'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     # Admin
     shot_lineup_jpeg:
         definition: '@shot_context/editorial/line_up/{name}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_process_scripts_deadline:
         definition: '@shot_context/scripts/deadline'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_process_mov:
         definition: '@shot_context/renders/process/{Codec}/{Shot}_v{version}.mov'
-        root_name: 'project_pipeline'               
+        root_name: 'project_storage_pix'
     # resolve_review_mov: 
     #     definition: 'editorial/resolve/review/{YYYY}{MM}{DD}_Resolve_Review/{ampm}/{Shot}_{task_name}[_{name}]_v{version}.mov'
-    #     root_name: 'project_pipeline'
+    #     root_name: 'project_storage_pix'
     # resolve_review_mov_secondary: 
     #     definition: 'editorial/resolve/review/{YYYY}{MM}{DD}_Resolve_Review/{ampm}/{Shot}_{task_name}[_{name}]_v{version}.mov'
     #     root_name: 'secondary'                
@@ -324,93 +324,93 @@ paths:
     # The location of shot rushes references, proxy jpegs and quicktimes
     shot_rushes_root:
         definition: '@rushes_root/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_rushes_main_jpg:
         definition: '@rushes_root/jpeg/main/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_root:
         definition: '@plates_root/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_main_proxy:
         definition: '@plates_root/main/proxy/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_main_reformat:
         definition: '@plates_root/main/reformat/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_bg_proxy:
         definition: '@plates_root/background/proxy/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_bg_reformat:
         definition: '@plates_root/background/reformat/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_rushes_jpeg:
         definition: '@rushes_root/jpeg/{Shot}_v{version}.{SEQ}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_rushes_mov:
         definition: '@rushes_root/mov/{Shot}_v{version}.mov'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_rushes_filmstrip:
         definition: '@rushes_root/filmstrip/{Shot}_v{version}.jpeg'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # DPX
     shot_plates_main_dpx:
         definition: '@plates_root/main/{Rush}/{Rush}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_main_proxy_dpx:
         definition: '@plates_root/main/proxy/{Rush}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_main_reformat_dpx:
         definition: '@plates_root/main/reformat/{Rush}.{SEQ}.dpx'        
     shot_plates_bg_dpx:
         definition: '@plates_root/background/{Rush}/{Rush}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_bg_proxy_dpx:
         definition: '@plates_root/background/proxy/{Rush}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_bg_reformat_dpx:
         definition: '@plates_root/background/reformat/{Rush}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_rushes_ref_dpx:
         definition: '@plates_root/reference/{Rush}/{Rush}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_rushes_elem_dpx:
         definition: '@plates_root/element/{Rush}/{Rush}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_render_process_version_dpx:
         definition: '@render_root/{task_name}/{Shot}_v{version}/{Shot}_v{version}.{SEQ}.dpx'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # EXR
     shot_plates_main_exr:
         definition: '@plates_root/main/{Rush}/{Rush}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_main_proxy_exr:
         definition: '@plates_root/main/proxy/{Rush}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_main_reformat_exr:
         definition: '@plates_root/main/reformat/{Rush}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_bg_exr:
         definition: '@plates_root/background/{Rush}/{Rush}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_bg_proxy_exr:
         definition: '@plates_root/background/proxy/{Rush}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_plates_bg_reformat_exr:
         definition: '@plates_root/background/reformat/{Rush}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_rushes_ref_exr:
         definition: '@plates_root/reference/{Rush}/{Rush}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_rushes_elem_exr:
         definition: '@plates_root/element/{Rush}/{Rush}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     shot_render_process_version_exr:
         definition: '@render_root/{task_name}/{Shot}_v{version}/{Shot}_v{version}.{SEQ}.exr'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
     # RETIME FCURVE EXPORTS
     shot_retime_curve:
             definition: '@shot_context/export/retime/{Shot}[_{name}]_v{version}.txt'
-            root_name: 'project_pipeline'
+            root_name: 'project_storage_pix'
 
     # global shot root locations for the different locations to save to
     shot_render_test_global:
@@ -418,7 +418,7 @@ paths:
         root_name: 'secondary'
     shot_render_global:
         definition: '@shot_context/'
-        root_name: 'project_pipeline'
+        root_name: 'project_storage_pix'
 
     # global asset root locations for the different locations to save to
     asset_render_test_global:
@@ -426,5 +426,4 @@ paths:
         root_name: 'secondary'
     asset_render_global:
         definition: '@asset_context/'
-        root_name: 'project_pipeline'
-
+        root_name: 'project_storage_pix'


### PR DESCRIPTION
- Updating project pix storage root name from project_pipeline to project_storage_pix. This should remove the project creation step where we have to find and replace the storage name in every template on the project. In turn this should make updating live configurations much easier.
- Updated the version of tk-core to the latest, v0.20.23