### PR TITLE
downshift multi_publish2 version

### DIFF
--- a/env/includes/app_locations.yml
+++ b/env/includes/app_locations.yml
@@ -43,7 +43,8 @@ apps.tk-multi-loader2.location:
 apps.tk-multi-publish2.location:
   type: app_store
   name: tk-multi-publish2
-  version: v2.10.1
+  # version: v2.10.1
+  version: v2.6.7
 apps.tk-multi-pythonconsole.location:
   type: app_store
   name: tk-multi-pythonconsole


### PR DESCRIPTION
the new version of the tk-multi-publish2 got the changes of the publish_file hook that breaks down many our publish plugins for Maya and Houdini, that's why we need to down shift the version until the code is corrected.