### PR TITLE
Revert tk-multy-publish2 version

### DIFF
--- a/env/includes/app_locations.yml
+++ b/env/includes/app_locations.yml
@@ -43,8 +43,8 @@ apps.tk-multi-loader2.location:
 apps.tk-multi-publish2.location:
   type: app_store
   name: tk-multi-publish2
-  # version: v2.10.1
-  version: v2.6.7
+  version: v2.10.1
+  #version: v2.6.7
 apps.tk-multi-pythonconsole.location:
   type: app_store
   name: tk-multi-pythonconsole


### PR DESCRIPTION
Revert version of tk-multy-publish2 app after copy-to-publish logic fixes.