### PR TITLE
#31232: Reverting tk-core version to v0.23.4

### DIFF
--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -14,4 +14,4 @@
 location:
   type: app_store
   name: tk-core
-  version: v0.24.0
+  version: v0.23.4


### PR DESCRIPTION
Related ticket:
[#31232: Deprecation error in config core](https://screenscene.shotgunstudio.com/detail/Ticket/31232)

Reverting the tk-core version as it is causing an entirely different error to occur when sgtk is imported.