### PR TITLE
#31232: Deprecation error in config core

### DIFF
--- a/env/includes/engine_locations.yml
+++ b/env/includes/engine_locations.yml
@@ -61,7 +61,7 @@ engines.tk-motionbuilder.location:
 engines.tk-nuke.location:
   type: app_store
   name: tk-nuke
-  version: v0.16.0
+  version: v0.16.4
 engines.tk-photoshopcc.location:
   type: app_store
   name: tk-photoshopcc


### PR DESCRIPTION
Ticket:
[#31232: Deprecation error in config core](https://screenscene.shotgunstudio.com/detail/Ticket/31232)

Updating tk-nuke engine to latest version as this removes the deprecation error during Nuke startup.